### PR TITLE
Fix code scanning alert no. 34: Use of externally-controlled format string

### DIFF
--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -85,7 +85,7 @@ router.use((err: any, req: Request, res: Response, next: NextFunction): void => 
     return;
   }
 
-  console.error(`Erro no tratamento da rota: ${req.path}`, err);
+  console.error('Erro no tratamento da rota: %s', req.path, err);
   res.status(500).json({ message: 'Ocorreu um erro interno no servidor.' });
 });
 


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/34](https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/34)

To fix the problem, we should ensure that the untrusted `req.path` value is properly sanitized before being included in the log message. One way to achieve this is by using the `%s` specifier in the format string and passing the `req.path` as an argument to `console.error`. This approach ensures that the untrusted input is treated as a string and does not interfere with the format string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
