### PR TITLE
Fix code scanning alert no. 32: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -124,7 +124,7 @@ export const forgotPassword = async (req: Request, res: Response, next: NextFunc
       return handleValidationError(res, 'O e-mail é obrigatório');
     }
 
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email: { $eq: email } });
     if (!user) {
       return handleValidationError(res, 'Usuário não encontrado');
     }


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/32](https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/32)

To fix the problem, we need to ensure that the `email` parameter is sanitized before being used in the MongoDB query. We can use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
