### PR TITLE
Fix code scanning alert no. 28: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controllers/snippetController.ts
+++ b/backend/src/controllers/snippetController.ts
@@ -91,9 +91,14 @@ export const updateSnippet = async (req: Request, res: Response, next: NextFunct
   try {
     const { title, description, language, tags, code, favorite } = req.body;
 
+    // Validate input data
+    if (typeof title !== 'string' || typeof description !== 'string' || typeof language !== 'string' || !Array.isArray(tags) || typeof code !== 'string' || typeof favorite !== 'boolean') {
+      return handleValidationError(res, 'Dados inválidos.');
+    }
+
     const snippet = await Snippet.findByIdAndUpdate(
       req.params.id,
-      { title, description, language, tags, code, favorite },
+      { $set: { title, description, language, tags, code, favorite } },
       { new: true, runValidators: true }
     );
 


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/28](https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/28)

To fix the problem, we need to ensure that the user input is properly sanitized and validated before being used in the database query. We can achieve this by using Mongoose's `$set` operator to explicitly set the fields to be updated, ensuring that the user input is treated as literal values. Additionally, we should validate the input data to ensure it meets the expected format and constraints.

1. Use the `$set` operator in the `findByIdAndUpdate` method to safely update the document fields.
2. Validate the input data before using it in the query to ensure it meets the expected format and constraints.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
