### PR TITLE
Fix code scanning alert no. 33: Use of externally-controlled format string

### DIFF
--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -60,7 +60,7 @@ const validateRequest = (req: Request, res: Response, next: NextFunction): void 
 const asyncHandler = (fn: Function) => (req: any, res: any, next: any) => {
   console.log(`Executando função assíncrona para a rota: ${req.path}`);
   Promise.resolve(fn(req, res, next)).catch((error) => {
-    console.error(`Erro ao executar função assíncrona para a rota: ${req.path}`, error);
+    console.error('Erro ao executar função assíncrona para a rota: %s', req.path, error);
     next(error);
   });
 };


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/33](https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/33)

To fix the problem, we should ensure that the untrusted data (`req.path`) is properly sanitized before being included in the log message. The best way to do this is to use a `%s` specifier in the format string and pass the untrusted data as a corresponding argument. This approach ensures that the untrusted data is treated as a string and prevents any unintended format specifiers from being interpreted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
