### PR TITLE
Fix code scanning alert no. 36: Incomplete multi-character sanitization

### DIFF
--- a/backend/src/models/Snippet.ts
+++ b/backend/src/models/Snippet.ts
@@ -86,9 +86,10 @@ SnippetSchema.pre<ISnippet>('save', function (next) {
 
   // Remover atributos perigosos
   let previousCode;
+  const dangerousAttrRegex = /on\w+=(["'])(?:(?=(\\?))\2.)*?\1/g;
   do {
     previousCode = this.code;
-    this.code = this.code.replace(/on\w+="[^"]*"/g, '').replace(/on\w+='[^']*'/g, '');
+    this.code = this.code.replace(dangerousAttrRegex, '');
   } while (this.code !== previousCode);
 
   // Remover URLs perigosas em estilos inline


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/36](https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/36)

To fix the problem, we should ensure that the regular expression replacement for dangerous attributes is applied repeatedly until no more replacements can be performed. This can be achieved by modifying the `do-while` loop to handle all occurrences of dangerous attributes effectively. Additionally, we should consider using a well-tested sanitization library to handle this task more robustly.

The best way to fix the problem without changing existing functionality is to modify the `do-while` loop to ensure that all occurrences of dangerous attributes are removed. We will also add a check to handle both double-quoted and single-quoted attributes in a single pass.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
