### PR TITLE
Fix code scanning alert no. 37: Incomplete multi-character sanitization

### DIFF
--- a/backend/src/models/Snippet.ts
+++ b/backend/src/models/Snippet.ts
@@ -86,7 +86,7 @@ SnippetSchema.pre<ISnippet>('save', function (next) {
 
   // Remover atributos perigosos
   let previousCode;
-  const dangerousAttrRegex = /on\w+=(["'])(?:(?=(\\?))\2.)*?\1/g;
+  const dangerousAttrRegex = /on\w+=(["'])(?:(?=(\\?))\2.)*?\1|javascript:|data:|vbscript:/gi;
   do {
     previousCode = this.code;
     this.code = this.code.replace(dangerousAttrRegex, '');


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/37](https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/37)

To fix the problem, we need to ensure that all instances of dangerous attributes are removed from the `code` string. The current approach of using a loop to repeatedly apply the regular expression replacement is correct, but we should enhance the regular expression to be more comprehensive and ensure that it catches all possible dangerous attributes.

We will:
1. Update the regular expression to be more robust.
2. Ensure that the loop continues until no more replacements can be performed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
