### PR TITLE
Fix code scanning alert no. 40: Database query built from user-controlled sources

### DIFF
--- a/backend/src/repositories/userRepository.ts
+++ b/backend/src/repositories/userRepository.ts
@@ -6,7 +6,7 @@ export async function findUserByEmail(email: string): Promise<IUser | null> {
 }
 
 export async function findUserByUsername(username: string): Promise<IUser | null> {
-  return User.findOne({ username });
+  return User.findOne({ username: { $eq: username } });
 }
 
 export async function createUser(username: string, email: string, hashedPassword: string): Promise<IUser> {


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/40](https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/40)

To fix the problem, we need to ensure that the user input is properly sanitized before being used in the MongoDB query. One way to achieve this is by using the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
