### PR TITLE
Fix code scanning alert no. 39: Database query built from user-controlled sources

### DIFF
--- a/backend/src/repositories/userRepository.ts
+++ b/backend/src/repositories/userRepository.ts
@@ -2,7 +2,7 @@ import { Types } from 'mongoose';
 import { User, IUser } from '../models/User';
 
 export async function findUserByEmail(email: string): Promise<IUser | null> {
-  return User.findOne({ email }).select('+password');
+  return User.findOne({ email: { $eq: email } }).select('+password');
 }
 
 export async function findUserByUsername(username: string): Promise<IUser | null> {


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/39](https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/39)

To fix the problem, we need to ensure that the user-provided `email` parameter is safely embedded into the MongoDB query. This can be achieved by using the `$eq` operator to ensure that the `email` is treated as a literal value. This approach prevents any potential injection attacks by interpreting the user input as a simple value rather than a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
