### PR TITLE
Fix code scanning alert no. 37: Incomplete multi-character sanitization

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -31,7 +31,8 @@
     "nodemailer": "^6.9.16",
     "nodemon": "^3.1.7",
     "uuid": "^11.0.3",
-    "validator": "^13.12.0"
+    "validator": "^13.12.0",
+    "sanitize-html": "^2.13.1"
   },
   "devDependencies": {
     "@types/axios": "^0.14.4",


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/37](https://github.com/Jonhvmp/SnapSnippet/security/code-scanning/37)

To fix the problem, we should ensure that the sanitization process is thorough and handles all possible edge cases. One effective way to achieve this is by using a well-tested sanitization library, such as `sanitize-html`, which is specifically designed to handle HTML sanitization and is more likely to cover all corner cases.

We will replace the custom sanitization logic with the `sanitize-html` library to ensure that the `code` field is properly sanitized before saving it to the database.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
